### PR TITLE
Fix nvs_flash_generate_keys

### DIFF
--- a/components/nvs_flash/src/nvs_api.cpp
+++ b/components/nvs_flash/src/nvs_api.cpp
@@ -538,16 +538,25 @@ extern "C" esp_err_t nvs_flash_generate_keys(const esp_partition_t* partition, n
     }
 
     for(uint8_t cnt = 0; cnt < NVS_KEY_SIZE; cnt++) {
-        cfg->eky[cnt] = 0xff;
-        cfg->tky[cnt] = 0xee;
+        /* Adjacent 16-byte blocks should be different */
+        if((cnt / 16) & 1 == 0) {
+            cfg->eky[cnt] = 0xff;
+            cfg->tky[cnt] = 0xee;
+        }
+        else {
+            cfg->eky[cnt] = 0x99;
+            cfg->tky[cnt] = 0x88;
+        }
     }
-
-    err = esp_partition_write(partition, 0, cfg->eky, NVS_KEY_SIZE);
+    
+    /* Write without encryption */
+    err = esp_partition_write_raw(partition, 0, cfg->eky, NVS_KEY_SIZE);
     if(err != ESP_OK) {
         return err;
     }
-
-    err = esp_partition_write(partition, NVS_KEY_SIZE, cfg->tky, NVS_KEY_SIZE);
+    
+    /* Write without encryption */
+    err = esp_partition_write_raw(partition, NVS_KEY_SIZE, cfg->tky, NVS_KEY_SIZE);
     if(err != ESP_OK) {
         return err;
     }


### PR DESCRIPTION
nvs_flash_generate_keys has been broken since  https://github.com/espressif/esp-idf/commit/aca9ec28b3d091a73605ee89ab63f8f76a996491 which bypassed the whole concept of using flash encryption to create a random key and resulted in a known universal key!

Also keys should not be generated from two identical 16 byte sequences as it reduces the keyspace (see [docs](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/security/flash-encryption.html#limitations-of-flash-encryption))

> Flash encryption does not prevent an attacker from understanding the high-level layout of the flash. This is because the same AES key is used for every pair of adjacent 16 byte AES blocks. When these adjacent 16 byte blocks contain identical content (such as empty or padding areas), these blocks will encrypt to produce matching pairs of encrypted blocks. This may allow an attacker to make high-level comparisons between encrypted devices (i.e. to tell if two devices are probably running the same firmware version).
> 
> For the same reason, an attacker can always tell when a pair of adjacent 16 byte blocks (32 byte aligned) contain two identical 16 byte sequences. Keep this in mind if storing sensitive data on the flash, design your flash storage so this doesn’t happen (using a counter byte or some other non-identical value every 16 bytes is sufficient). NVS Encryption deals with this and is suitable for many uses.

